### PR TITLE
v3.1.0

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Generate coverage report
         run: |
           dart pub global activate coverage
-          dart run test --coverage=./coverage
+          dart run test -c source --coverage=./coverage
           dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o ./coverage/lcov.info -i ./coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,24 @@
-## 3.0.3
+## 3.1.0
 
-- Fix path resolution on Windows.
-- sdk: '>=2.15.0 <3.0.0'
+- `ResourceLoader`:
+  - Added method `resolveUri`.
+- `Resource.uriResolved` now respects `ResourceLoader` (calls `_loader.resolveUri`).
+- `PackageLoader`:
+  - All constructor parameters are named parameters now.
+    - `loader` is optional.
+- `resolve_io.dart`
+  - Fix path resolution on Windows.
+  - Also checks for package files in the entry point directory (script or executable directory).
+- `dart_test.yaml`
+  - Added `exe` compiler to tests:
+    - `compilers: [source, exe]`
+- `resource_test.dart`:
+  - Added test with existent file, to check a real URI resolution in VM (source and exe compilers).
+
+- sdk: '>=2.18.0 <4.0.0'
+- collection: ^1.17.1
+- typed_data: ^1.3.2
+- test: ^1.24.3
 
 ## 3.0.2
 

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -18,3 +18,5 @@ define_platforms:
         linux: firefox-esr
 
 platforms: [vm, chrome]
+
+compilers: [source, exe]

--- a/lib/resource/file-sample.txt
+++ b/lib/resource/file-sample.txt
@@ -1,0 +1,1 @@
+This is a file sample to test `resolveUri`.

--- a/lib/src/package_loader.dart
+++ b/lib/src/package_loader.dart
@@ -25,6 +25,12 @@ class PackageLoader implements ResourceLoader {
       : _loader = loader ?? const DefaultLoader();
 
   @override
+  Uri parseUri(String s) {
+    var uriResolver = this.uriResolver ?? ResourceURIResolver.defaultResolver;
+    return uriResolver.parseUri(s);
+  }
+
+  @override
   Future<Uri> resolveUri(Uri uri) {
     var uriResolver = this.uriResolver ?? ResourceURIResolver.defaultResolver;
     return uriResolver.resolveUriCached(uri);

--- a/lib/src/package_loader.dart
+++ b/lib/src/package_loader.dart
@@ -27,7 +27,7 @@ class PackageLoader implements ResourceLoader {
   @override
   Future<Uri> resolveUri(Uri uri) {
     var uriResolver = this.uriResolver ?? ResourceURIResolver.defaultResolver;
-    return uriResolver.resolveUri(uri);
+    return uriResolver.resolveUriCached(uri);
   }
 
   @override

--- a/lib/src/package_loader.dart
+++ b/lib/src/package_loader.dart
@@ -5,10 +5,6 @@
 import 'dart:async' show Future, Stream;
 import 'dart:convert' show Encoding;
 
-import 'resolve_none.dart'
-    if (dart.library.html) 'resolve_html.dart'
-    if (dart.library.io) 'resolve_io.dart';
-
 import 'resource_loader.dart';
 
 /// Implementation of [ResourceLoader] that accepts relative and package: URIs.
@@ -20,7 +16,19 @@ import 'resource_loader.dart';
 /// object, and just want to load a package resource directly.
 class PackageLoader implements ResourceLoader {
   final ResourceLoader _loader;
-  const PackageLoader(ResourceLoader loader) : _loader = loader;
+
+  /// The [Uri] resolver, used by [resolveUri].
+  /// - If not defined will use [ResourceURIResolver.defaultResolver].
+  final ResourceURIResolver? uriResolver;
+
+  const PackageLoader({ResourceLoader? loader, this.uriResolver})
+      : _loader = loader ?? const DefaultLoader();
+
+  @override
+  Future<Uri> resolveUri(Uri uri) {
+    var uriResolver = this.uriResolver ?? ResourceURIResolver.defaultResolver;
+    return uriResolver.resolveUri(uri);
+  }
 
   @override
   Stream<List<int>> openRead(Uri uri) async* {

--- a/lib/src/resource.dart
+++ b/lib/src/resource.dart
@@ -5,9 +5,7 @@
 import 'dart:async' show Future, Stream;
 import 'dart:convert' show Encoding;
 
-import 'resolve_none.dart'
-    if (dart.library.html) 'resolve_html.dart'
-    if (dart.library.io) 'resolve_io.dart';
+import 'package:resource_portable/src/package_loader.dart';
 
 import 'resource_loader.dart';
 
@@ -47,7 +45,7 @@ class Resource {
   /// current platform.
   const Resource(uri, {ResourceLoader? loader})
       : _uri = uri,
-        _loader = loader ?? const DefaultLoader();
+        _loader = loader ?? const PackageLoader();
 
   /// The location URI of this resource.
   ///
@@ -78,24 +76,10 @@ class Resource {
     return _loader.readAsString(uri, encoding: encoding);
   }
 
-  Future<Uri> get uriResolved => _ResolvedURIs.resolveURI(uri);
+  Future<Uri> get uriResolved => _loader.resolveUri(uri);
 
   @override
   String toString() {
     return 'Resource{uri: $_uri ; loader: $_loader}';
-  }
-}
-
-class _ResolvedURIs {
-  static final Map<Uri, Uri> _resolvedURIs = {};
-
-  static Future<Uri> resolveURI(Uri uri) async {
-    var resolvedURI = _resolvedURIs[uri];
-    if (resolvedURI != null) return resolvedURI;
-
-    resolvedURI = await resolveUri(uri);
-    _resolvedURIs[uri] = resolvedURI;
-
-    return resolvedURI;
   }
 }

--- a/lib/src/resource.dart
+++ b/lib/src/resource.dart
@@ -52,7 +52,18 @@ class Resource {
   /// This is a [Uri] of the `uri` parameter given to the constructor.
   /// If the parameter was a string that did not contain a valid URI,
   /// reading `uri` will fail.
-  Uri get uri => (_uri is String) ? Uri.parse(_uri) : (_uri as Uri);
+  Uri get uri => _normalizeUri();
+
+  Uri _normalizeUri() {
+    var uri = _uri;
+    if (uri == null) {
+      return Uri.base;
+    } else if (uri is Uri) {
+      return uri;
+    } else {
+      return _loader.parseUri(uri.toString());
+    }
+  }
 
   /// Reads the resource content as a stream of bytes.
   Stream<List<int>> openRead() async* {

--- a/lib/src/resource_loader.dart
+++ b/lib/src/resource_loader.dart
@@ -114,7 +114,7 @@ class DefaultLoader implements ResourceLoader {
   Future<Uri> resolveUri(Uri uri) {
     final uriResolver = this.uriResolver;
     if (uriResolver != null) {
-      return uriResolver.resolveUri(uri);
+      return uriResolver.resolveUriCached(uri);
     }
     return Future.value(uri);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,17 @@
 name: resource_portable
-version: 3.0.3
+version: 3.1.0
 description: Reading resource data from files in a portable way (VM, Web, Flutter and native).
 homepage: https://github.com/gmpassos/resource_portable
 
 environment:
-  sdk: '>=2.15.0 <3.0.0'
+  sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
-  collection: ^1.17.0
+  collection: ^1.17.1
   path: ^1.8.3
-  typed_data: ^1.3.1
+  typed_data: ^1.3.2
 
 dev_dependencies:
-  test: ^1.22.1
+  test: ^1.24.3
   lints: ^2.0.1
   dependency_validator: ^3.2.2

--- a/test/resource_test.dart
+++ b/test/resource_test.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'dart:isolate';
 import 'package:resource_portable/resource.dart';
 import 'package:resource_portable/src/resolve_io.dart' as resolver;
+import 'package:resource_portable/src/resource_loader.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -90,9 +91,10 @@ class LogLoader implements ResourceLoader {
   }
 
   @override
-  Future<Uri> resolveUri(Uri uri) {
-    return resolveTestUri(uri);
-  }
+  Uri parseUri(String s) => ResourceURIResolver.defaultParseUri(s);
+
+  @override
+  Future<Uri> resolveUri(Uri uri) => resolveTestUri(uri);
 }
 
 Future<Uri> resolveTestUri(Uri source) async {

--- a/test/resource_test.dart
+++ b/test/resource_test.dart
@@ -3,36 +3,40 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('vm')
-
 import 'dart:async' show Future, Stream;
 import 'dart:convert' show Encoding, ascii;
-import 'dart:isolate' show Isolate;
+import 'dart:io';
+import 'dart:isolate';
 import 'package:resource_portable/resource.dart';
+import 'package:resource_portable/src/resolve_io.dart' as resolver;
 import 'package:test/test.dart';
 
 void main() {
   Uri pkguri(path) => Uri(scheme: 'package', path: path);
 
-  Future<Uri?> resolve(Uri source) async {
-    if (source.scheme == 'package') {
-      return Isolate.resolvePackageUri(source);
-    }
-    return Uri.base.resolveUri(source);
-  }
-
   group('loading', () {
-    Future testLoad(Uri uri) async {
+    Future testLoad(Uri uri, {bool fileExists = false}) async {
       var loader = LogLoader();
       var resource = Resource(uri, loader: loader);
+      var resolved = await resolveTestUri(uri);
+
+      expect(resolved.path, isNotEmpty);
+
+      var expectedBytes = loadUriBytes(fileExists ? resolved : uri);
+
+      expect(
+        expectedBytes,
+        fileExists ? isNot([0, 0, 0]) : equals([0, 0, 0]),
+      );
+
       var res = await resource.openRead().toList();
-      var resolved = await resolve(uri);
-      expect(res, [
-        [0, 0, 0]
-      ]);
+      expect(res, [expectedBytes]);
+
       var res1 = await resource.readAsBytes();
-      expect(res1, [0, 0, 0]);
+      expect(res1, expectedBytes);
+
       var res2 = await resource.readAsString(encoding: ascii);
-      expect(res2, '\x00\x00\x00');
+      expect(res2, String.fromCharCodes(expectedBytes));
 
       expect(loader.requests, [
         ['Stream', resolved],
@@ -41,10 +45,15 @@ void main() {
       ]);
     }
 
-    test('load package: URIs', () async {
-      await testLoad(pkguri('resource_portable/bar/baz'));
+    test('load package: URIs (file exists)', () async {
+      await testLoad(pkguri('resource_portable/resource/file-sample.txt'),
+          fileExists: true);
+    });
+
+    test('load package: URIs (non-existent file)', () async {
       await testLoad(pkguri('test/foo/baz'));
     });
+
     test('load non-pkgUri', () async {
       await testLoad(Uri.parse('file://localhost/something?x#y'));
       await testLoad(Uri.parse('http://auth/something?x#y'));
@@ -57,6 +66,7 @@ void main() {
 
 class LogLoader implements ResourceLoader {
   final List requests = [];
+
   void reset() {
     requests.clear();
   }
@@ -64,18 +74,52 @@ class LogLoader implements ResourceLoader {
   @override
   Stream<List<int>> openRead(Uri uri) async* {
     requests.add(['Stream', uri]);
-    yield [0x00, 0x00, 0x00];
+    yield loadUriBytes(uri);
   }
 
   @override
   Future<List<int>> readAsBytes(Uri uri) async {
     requests.add(['Bytes', uri]);
-    return [0x00, 0x00, 0x00];
+    return loadUriBytes(uri);
   }
 
   @override
   Future<String> readAsString(Uri uri, {Encoding? encoding}) async {
     requests.add(['String', uri, encoding]);
-    return '\x00\x00\x00';
+    return String.fromCharCodes(loadUriBytes(uri));
   }
+
+  @override
+  Future<Uri> resolveUri(Uri uri) {
+    return resolveTestUri(uri);
+  }
+}
+
+Future<Uri> resolveTestUri(Uri source) async {
+  if (source.scheme == 'package') {
+    var fileExists = source.path.startsWith('resource_portable/');
+
+    if (fileExists) {
+      return resolver.resolveUri(source);
+    } else {
+      var resolved = await Isolate.resolvePackageUri(source);
+      resolved ??= source;
+      return resolved;
+    }
+  }
+  return Uri.base.resolveUri(source);
+}
+
+List<int> loadUriBytes(Uri uri) {
+  if (uri.scheme == 'file') {
+    try {
+      var file = File(uri.toFilePath());
+      if (file.existsSync()) {
+        return file.readAsBytesSync();
+      }
+    } catch (_) {}
+  }
+
+  // no existent files:
+  return [0x00, 0x00, 0x00];
 }


### PR DESCRIPTION
- `ResourceLoader`:
  - Added method `resolveUri`.
- `Resource.uriResolved` now respects `ResourceLoader` (calls `_loader.resolveUri`).
- `PackageLoader`:
  - All constructor parameters are named parameters now. - `loader` is optional.
- `resolve_io.dart`
  - Fix path resolution on Windows.
  - Also checks for package files in the entry point directory (script or executable directory).
- `dart_test.yaml`
  - Added `exe` compiler to tests: - `compilers: [source, exe]`
- `resource_test.dart`:
  - Added test with existent file, to check a real URI resolution in VM (source and exe compilers).

- sdk: '>=2.18.0 <4.0.0'
- collection: ^1.17.1
- typed_data: ^1.3.2
- test: ^1.24.3